### PR TITLE
Upgrade outdated bower packages

### DIFF
--- a/Bowerfile
+++ b/Bowerfile
@@ -7,4 +7,4 @@ asset "masonry", "4.0.0"
 asset "jquery-ui", "1.11.4"
 asset "jquery-tagit", "6ccd2de95e"
 
-asset "materialize", "0.97.0"
+asset "materialize", "0.97.5"

--- a/Bowerfile
+++ b/Bowerfile
@@ -3,7 +3,7 @@
 asset "jquery", "2.2.0"
 asset "jquery-ujs", "1.2.0"
 asset "pdfjs-dist", "1.1.205"
-asset "masonry", "3.3.0"
+asset "masonry", "4.0.0"
 asset "jquery-ui", "1.11.4"
 asset "jquery-tagit", "6ccd2de95e"
 

--- a/Bowerfile
+++ b/Bowerfile
@@ -1,7 +1,7 @@
 # Check out https://github.com/42dev/bower-rails#ruby-dsl-configuration for more options
 
-asset "jquery", "2.1.4"
-asset "jquery-ujs", "1.0.3"
+asset "jquery", "2.2.0"
+asset "jquery-ujs", "1.2.0"
 asset "pdfjs-dist", "1.1.205"
 asset "masonry", "3.3.0"
 asset "jquery-ui", "1.11.4"

--- a/app/assets/javascripts/app.js.coffee
+++ b/app/assets/javascripts/app.js.coffee
@@ -6,7 +6,7 @@ $ ->
           itemSelector: ".grid-item",
           columnWidth: 250,
           gutter: 10,
-          isFitWidth: true
+          fitWidth: true
         }
       )
   $(".datepicker").pickadate(

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,12 +14,9 @@
 //= require jquery-ujs
 //= require pdfjs-dist
 //= require pdfjs-dist/build/pdf.worker
-//= require eventEmitter
-//= require eventie
-//= require doc-ready
+//= require ev-emitter
 //= require matches-selector
 //= require fizzy-ui-utils
-//= require get-style-property
 //= require get-size
 //= require outlayer/item
 //= require outlayer

--- a/vendor/assets/bower.json
+++ b/vendor/assets/bower.json
@@ -1,8 +1,8 @@
 {
   "name": "dsl-generated dependencies",
   "dependencies": {
-    "jquery": "2.1.4",
-    "jquery-ujs": "1.0.3",
+    "jquery": "2.2.0",
+    "jquery-ujs": "1.2.0",
     "pdfjs-dist": "1.1.205",
     "masonry": "3.3.0",
     "jquery-ui": "1.11.4",

--- a/vendor/assets/bower.json
+++ b/vendor/assets/bower.json
@@ -7,6 +7,6 @@
     "masonry": "4.0.0",
     "jquery-ui": "1.11.4",
     "jquery-tagit": "6ccd2de95e",
-    "materialize": "0.97.0"
+    "materialize": "0.97.5"
   }
 }

--- a/vendor/assets/bower.json
+++ b/vendor/assets/bower.json
@@ -4,7 +4,7 @@
     "jquery": "2.2.0",
     "jquery-ujs": "1.2.0",
     "pdfjs-dist": "1.1.205",
-    "masonry": "3.3.0",
+    "masonry": "4.0.0",
     "jquery-ui": "1.11.4",
     "jquery-tagit": "6ccd2de95e",
     "materialize": "0.97.0"


### PR DESCRIPTION
Upgrade outdated bower packages:
- jquery      v2.1.4  to v2.2.0
- jquery-ujs  v1.0.3  to v1.2.0
- masonry     v3.3.0  to v4.0.0
- materialize v0.97.0 to 0.97.5

pdfjs-dist diff is so large, so upgrade it next time.
