### PR TITLE
Can expect that `name` returns by all omniauth providers

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -14,7 +14,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     def build_resource(hash = nil)
       super
       auth = session[:omniauth]
-      @user.name = auth.extra.raw_info.name
+      @user.name = auth.info.name
       account = @user.user_accounts.find_or_initialize_by(provider: auth.provider, uid: auth.uid)
       account.build_auth_info(auth)
     end


### PR DESCRIPTION
`name` is required key of omniauth auth hash.
https://github.com/omniauth/omniauth/wiki/Auth-Hash-Schema