### PR TITLE
Remove oauth tokens from user_accounts

### DIFF
--- a/app/models/user_account.rb
+++ b/app/models/user_account.rb
@@ -2,16 +2,13 @@
 #
 # Table name: user_accounts
 #
-#  id               :integer          not null, primary key
-#  user_id          :integer          not null
-#  provider         :string(255)      not null
-#  uid              :string(255)      not null
-#  image_url        :string(255)
-#  token            :string(511)      not null
-#  token_secret     :string(255)
-#  token_expires_at :datetime
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
+#  id         :integer          not null, primary key
+#  user_id    :integer          not null
+#  provider   :string(255)      not null
+#  uid        :string(255)      not null
+#  image_url  :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 # Indexes
 #
@@ -23,11 +20,7 @@ class UserAccount < ActiveRecord::Base
   belongs_to :user
 
   def build_auth_info(omniauth)
-    self.token = omniauth["credentials"]["token"]
     self.image_url = omniauth["info"]["image"]
-    if omniauth["credentials"]["expires_at"]
-      self.token_expires_at = Time.at(omniauth["credentials"]["expires_at"])
-    end
   end
 
   def save_auth_info(omniauth)

--- a/app/models/user_account.rb
+++ b/app/models/user_account.rb
@@ -7,6 +7,7 @@
 #  provider   :string(255)      not null
 #  uid        :string(255)      not null
 #  image_url  :string(255)
+#  raw_info   :text(65535)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
@@ -21,6 +22,7 @@ class UserAccount < ActiveRecord::Base
 
   def build_auth_info(omniauth)
     self.image_url = omniauth["info"]["image"]
+    self.raw_info  = omniauth["extra"]["raw_info"].to_json
   end
 
   def save_auth_info(omniauth)

--- a/db/migrate/20171022182219_remove_tokens_from_user_accounts.rb
+++ b/db/migrate/20171022182219_remove_tokens_from_user_accounts.rb
@@ -1,0 +1,7 @@
+class RemoveTokensFromUserAccounts < ActiveRecord::Migration
+  def change
+    remove_column :user_accounts, :token_expires_at, :datetime, after: :token_secret
+    remove_column :user_accounts, :token_secret, :string, after: :token
+    remove_column :user_accounts, :token, :string, null: false, after: :image_url
+  end
+end

--- a/db/migrate/20171022191944_add_raw_info_to_user_accounts.rb
+++ b/db/migrate/20171022191944_add_raw_info_to_user_accounts.rb
@@ -1,0 +1,5 @@
+class AddRawInfoToUserAccounts < ActiveRecord::Migration
+  def change
+    add_column :user_accounts, :raw_info, :text, after: :image_url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171022174931) do
+ActiveRecord::Schema.define(version: 20171022182219) do
 
   create_table "presentation_outlines", force: :cascade do |t|
     t.integer  "presentation_id", limit: 4,        null: false
@@ -66,15 +66,12 @@ ActiveRecord::Schema.define(version: 20171022174931) do
   add_index "tags", ["name"], name: "name", unique: true, using: :btree
 
   create_table "user_accounts", force: :cascade do |t|
-    t.integer  "user_id",          limit: 4,   null: false
-    t.string   "provider",         limit: 255, null: false
-    t.string   "uid",              limit: 255, null: false
-    t.string   "image_url",        limit: 255
-    t.string   "token",            limit: 511, null: false
-    t.string   "token_secret",     limit: 255
-    t.datetime "token_expires_at"
-    t.datetime "created_at",                   null: false
-    t.datetime "updated_at",                   null: false
+    t.integer  "user_id",    limit: 4,   null: false
+    t.string   "provider",   limit: 255, null: false
+    t.string   "uid",        limit: 255, null: false
+    t.string   "image_url",  limit: 255
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
   add_index "user_accounts", ["provider", "uid"], name: "provider_and_uid", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171022182219) do
+ActiveRecord::Schema.define(version: 20171022191944) do
 
   create_table "presentation_outlines", force: :cascade do |t|
     t.integer  "presentation_id", limit: 4,        null: false
@@ -66,12 +66,13 @@ ActiveRecord::Schema.define(version: 20171022182219) do
   add_index "tags", ["name"], name: "name", unique: true, using: :btree
 
   create_table "user_accounts", force: :cascade do |t|
-    t.integer  "user_id",    limit: 4,   null: false
-    t.string   "provider",   limit: 255, null: false
-    t.string   "uid",        limit: 255, null: false
+    t.integer  "user_id",    limit: 4,     null: false
+    t.string   "provider",   limit: 255,   null: false
+    t.string   "uid",        limit: 255,   null: false
     t.string   "image_url",  limit: 255
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.text     "raw_info",   limit: 65535
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
   end
 
   add_index "user_accounts", ["provider", "uid"], name: "provider_and_uid", unique: true, using: :btree


### PR DESCRIPTION
There is no need to save the access token because using oauth2 for only "Authentication".

Instead of saving tokens, save raw_info. This makes more flexibility.