### PR TITLE
Do not wrap checkbox in `.input-field`

### DIFF
--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -28,7 +28,11 @@ SimpleForm.setup do |config|
     # extensions by default, you can change `b.optional` to `b.use`.
 
     # Calculates maxlength from length validations for string inputs
+    # and/or database column lengths
     b.optional :maxlength
+
+    # Calculate minlength from length validations for string inputs
+    b.optional :minlength
 
     # Calculates pattern from format validations for string inputs
     b.optional :pattern
@@ -90,8 +94,7 @@ SimpleForm.setup do |config|
   # config.collection_wrapper_class = nil
 
   # You can wrap each item in a collection of radio/check boxes with a tag,
-  # defaulting to :span. Please note that when using :boolean_style = :nested,
-  # SimpleForm will force this option to be a label.
+  # defaulting to :span.
   # config.item_wrapper_tag = :span
 
   # You can define a class to use in all item wrappers. Defaulting to none.

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -166,6 +166,22 @@ SimpleForm.setup do |config|
 
   # Defines which i18n scope will be used in Simple Form.
   # config.i18n_scope = 'simple_form'
+
+  # materialize-css does not work with checkbox wrapped in `.input-field`
+  # options are same as :default
+  config.wrappers :materialize_boolean, hint_class: :field_with_hint, error_class: :field_with_errors do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :label_input
+    b.use :hint,  wrap_with: { tag: :span, class: :hint }
+    b.use :error, wrap_with: { tag: :span, class: :error }
+  end
+  config.wrapper_mappings = { boolean: :materialize_boolean }
 end
 
 # datepicker 対応


### PR DESCRIPTION
before:

```slim
.input-field
  input[type="checkbox"]
  label
```

after:

```slim
div
  input[type="checkbox"]
  label
```

before: https://gyazo.com/c71dd953e3e7f39296bab3a0bba3952c
after: https://gyazo.com/c457792de0de729a17b9f5fa34433d3c
