### PR TITLE
Tag search with strict_case_match

### DIFF
--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -1,0 +1,1 @@
+ActsAsTaggableOn.strict_case_match = true


### PR DESCRIPTION
Setting `ActsAsTaggableOn.strict_case_match` to `false` (default) is
depend on MySQL's collation and the collation of `tags.name` is `utf8-bin`.
With these, the search result is empty.

It is better that the collation of DB is case-sensiteve because there
are 'パパハハ' problem and '寿司ビール' problem in Japanese.
And the query `WHERE LOWER (name)` is inefficient because INDEX does not work.

So, change tag search to be case sensitive.