### PR TITLE
Change product name from ShareDoc to HellShake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## master (unreleased)
-[full changelog](https://github.com/onk/sharedoc/compare/v1.0.0...master)
+[full changelog](https://github.com/onk/hellshake/compare/v1.0.0...master)
 
 ## v1.0.0 (2015-12-01)
-[full changelog](https://github.com/onk/sharedoc/compare/v0.8.2...v1.0.0)
+[full changelog](https://github.com/onk/hellshake/compare/v0.8.2...v1.0.0)
 
 *   accessed_at が空のユーザがログイン状態を維持していたときにログインできなくなる不具合修正
 *   bump to rails 4.2.5
@@ -10,64 +10,64 @@
 *   スライドにアクセス数を表示
 
 ## v0.8.2 (2015-11-20)
-[full changelog](https://github.com/onk/sharedoc/compare/v0.8.1...v0.8.2)
+[full changelog](https://github.com/onk/hellshake/compare/v0.8.1...v0.8.2)
 
 *   pdf をアップロードしたときにエラーになる不具合修正
 
 ## v0.8.1 (2015-11-18)
-[full changelog](https://github.com/onk/sharedoc/compare/v0.8.0...v0.8.1)
+[full changelog](https://github.com/onk/hellshake/compare/v0.8.0...v0.8.1)
 
 *   ログインフォーム改善
 *   ログイン状態を維持するように
 
 ## v0.8.0 (2015-10-07)
-[full changelog](https://github.com/onk/sharedoc/compare/v0.7.3...v0.8.0)
+[full changelog](https://github.com/onk/hellshake/compare/v0.7.3...v0.8.0)
 
 *   ユーザの accessed_at を記録する
 *   Pdf2outlineJob を再実行可能に
 *   資料を URL を保ったまま再アップロードできるように
 
 ## v0.7.3 (2015-09-29)
-[full changelog](https://github.com/onk/sharedoc/compare/v0.7.2...v0.7.3)
+[full changelog](https://github.com/onk/hellshake/compare/v0.7.2...v0.7.3)
 
 *   atom 配信の不具合修正
 *   gem もろもろ最新化
 
 ## v0.7.2 (2015-08-14)
-[full changelog](https://github.com/onk/sharedoc/compare/v0.7.1...v0.7.2)
+[full changelog](https://github.com/onk/hellshake/compare/v0.7.1...v0.7.2)
 
 *   atom 配信
 
 ## v0.7.1 (2015-08-08)
-[full changelog](https://github.com/onk/sharedoc/compare/v0.7.0...v0.7.1)
+[full changelog](https://github.com/onk/hellshake/compare/v0.7.0...v0.7.1)
 
 *   検索結果のページネートを実装
 
 ## v0.7.0 (2015-08-05)
-[full changelog](https://github.com/onk/sharedoc/compare/v0.6.1...v0.7.0)
+[full changelog](https://github.com/onk/hellshake/compare/v0.6.1...v0.7.0)
 
 *   outline だけじゃなく tag や title でも検索できるように
 
 ## v0.6.1 (2015-08-03)
-[full changelog](https://github.com/onk/sharedoc/compare/v0.6.0...v0.6.1)
+[full changelog](https://github.com/onk/hellshake/compare/v0.6.0...v0.6.1)
 
 *   タグ検索時に is_public フラグが効いていなかった
 
 ## v0.6.0 (2015-08-03)
-[full changelog](https://github.com/onk/sharedoc/compare/v0.5.3...v0.6.0)
+[full changelog](https://github.com/onk/hellshake/compare/v0.5.3...v0.6.0)
 
 *   プレゼンを削除できる機能を追加
 *   アクセス数を取得しておく (まだユーザには見せない)
 
 ## v0.5.3 (2015-07-31)
-[full changelog](https://github.com/onk/sharedoc/compare/v0.5.2...v0.5.3)
+[full changelog](https://github.com/onk/hellshake/compare/v0.5.2...v0.5.3)
 
 *   copy fonts to public path
 *   DB のパスワードをコミットしないようにする
 *   表紙画像の横幅 250px の方がかわいい
 
 ## v0.5.2 (2015-07-29)
-[full changelog](https://github.com/onk/sharedoc/compare/v0.5.1...v0.5.2)
+[full changelog](https://github.com/onk/hellshake/compare/v0.5.1...v0.5.2)
 
 *   スマホで見た時用に viewport 指定入れる
 *   名前の全角空白が気になりすぎるので半角スペースに置換
@@ -75,37 +75,37 @@
 *   validation error を分かりやすくする
 
 ## v0.5.1 (2015-07-28)
-[full changelog](https://github.com/onk/sharedoc/compare/v0.5.0...v0.5.1)
+[full changelog](https://github.com/onk/hellshake/compare/v0.5.0...v0.5.1)
 
 *   zipang の生成ルールと slug の validation とを合わせる
 *   tag 検索の表示順を published_at desc に修正
 
 ## v0.5.0 (2015-07-27)
-[full changelog](https://github.com/onk/sharedoc/compare/v0.4.0...v0.5.0)
+[full changelog](https://github.com/onk/hellshake/compare/v0.4.0...v0.5.0)
 
 *   詳細ページから "Open File" ボタンを隠す
 *   タグ検索機能を実装
 
 ## v0.4.0 (2015-07-24)
-[full changelog](https://github.com/onk/sharedoc/compare/v0.3.1...v0.4.0)
+[full changelog](https://github.com/onk/hellshake/compare/v0.3.1...v0.4.0)
 
 *   タグ機能を追加
 *   非公開のスライドを表示しようとするとエラーになるのでリンク削除
 *   入力エラー時にエラーを目立たせた
 
 ## v0.3.1 (2015-07-23)
-[full changelog](https://github.com/onk/sharedoc/compare/v0.3.0...v0.3.1)
+[full changelog](https://github.com/onk/hellshake/compare/v0.3.0...v0.3.1)
 
 *   フォームの label を localize して分かりやすく
 *   slug の validation 追加
 
 ## v0.3.0 (2015-07-23)
-[full changelog](https://github.com/onk/sharedoc/compare/v0.2.0...v0.3.0)
+[full changelog](https://github.com/onk/hellshake/compare/v0.2.0...v0.3.0)
 
 *   詳細ページの URL を human readable に
 
 ## v0.2.0 (2015-07-22)
-[full changelog](https://github.com/onk/sharedoc/compare/v0.1.0...v0.2.0)
+[full changelog](https://github.com/onk/hellshake/compare/v0.1.0...v0.2.0)
 
 *   use simple_form gem
 *   タイトルを入力できるようにした

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-ShareDoc
+HellShake
 ================================
 
 clone of slideshare.net
@@ -19,7 +19,7 @@ System dependencies
 * libreoffice (if you need to upload ppt/pptx)
 * poppler (pdftotext,pdftocario)
 
-[https://github.com/onk/sharedoc/blob/master/INSTALL.md](https://github.com/onk/sharedoc/blob/master/INSTALL.md)
+[https://github.com/onk/hellshake/blob/master/INSTALL.md](https://github.com/onk/hellshake/blob/master/INSTALL.md)
 
 How to setup
 --------------------------------
@@ -27,8 +27,8 @@ How to setup
 ### Install
 
 ```sh
-$ git clone https://github.com/onk/sharedoc.git
-$ cd sharedoc
+$ git clone https://github.com/onk/hellshake.git
+$ cd hellshake
 $ bundle install
 $ npm install
 $ bundle exec rake bower:install

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,6 +1,6 @@
 nav.white
   .nav-wrapper.container
-    = link_to("Sharedoc", root_url, class: "brand-logo")
+    = link_to("HellShake", root_url, class: "brand-logo")
     ul.right
       li
         = form_tag(presentations_search_path, method: "GET") do

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -3,7 +3,7 @@ html
   head
     meta[name="viewport" content="width=device-width, initial-scale=1"]
     title
-      | Sharedoc
+      | HellShake
     = stylesheet_link_tag    'application', media: 'all'
     = javascript_include_tag 'application'
     = csrf_meta_tags
@@ -29,4 +29,4 @@ html
               p ログインすると使うことができます
       .footer-copyright
         .container
-          | 要望は #{link_to("github の issue", "https://github.com/onk/sharedoc/issues", class: "brown-text text-lighten-3")} にどうぞ
+          | 要望は #{link_to("github の issue", "https://github.com/onk/hellshake/issues", class: "brown-text text-lighten-3")} にどうぞ

--- a/app/views/presentations/index.atom.builder
+++ b/app/views/presentations/index.atom.builder
@@ -2,10 +2,10 @@ atom_feed(language: "ja-JP",
           root_url: root_url,
           url:      request.original_url,
           id:       root_url) do |feed|
-  feed.title    "Sharedoc"
+  feed.title    "HellShake"
   feed.subtitle "プレゼンテーション一覧"
   feed.updated  Presentation.is_public.maximum(:updated_at)
-  feed.author   "Sharedoc"
+  feed.author   "HellShake"
 
   @presentations.each do |presentation|
     feed.entry(presentation,

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,7 +15,7 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module Sharedoc
+module Hellshake
   class Application < Rails::Application
     Global.configure do |config|
       config.environment = Rails.env.to_s

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -19,14 +19,14 @@ default: &default
 
 development:
   <<: *default
-  database: sharedoc_development
+  database: hellshake_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: sharedoc_test
+  database: hellshake_test
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -49,6 +49,6 @@ test:
 #
 production:
   <<: *default
-  database: sharedoc_production
-  username: sharedoc
-  password: <%= ENV['SHAREDOC_DATABASE_PASSWORD'] %>
+  database: hellshake_production
+  username: hellshake
+  password: <%= ENV['HELLSHAKE_DATABASE_PASSWORD'] %>

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :mem_cache_store, key: "_sharedoc_session"
+Rails.application.config.session_store :mem_cache_store, key: "_hellshake_session"


### PR DESCRIPTION
This product name infringes their trademark.

http://www.jirokichi.co.jp/products/sharedoc

> ShareDoc®（シェアドック）は治郎吉商店の登録商標です。

So we've been forced to change our name.